### PR TITLE
Add support for priorityClassName

### DIFF
--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -56,6 +56,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.autorecovery.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.autorecovery.priorityClassName }}
+      priorityClassName: {{ .Values.autorecovery.priorityClassName }}
+    {{- end }}
     {{- if .Values.autorecovery.tolerations }}
       tolerations:
 {{- with .Values.autorecovery.tolerations }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -55,6 +55,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.bookkeeper.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.bookkeeper.priorityClassName }}
+      priorityClassName: {{ .Values.bookkeeper.priorityClassName }}
+    {{- end }}
     {{- if .Values.bookkeeper.tolerations }}
       tolerations:
 {{ toYaml .Values.bookkeeper.tolerations | indent 8 }}

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -58,6 +58,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.broker.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.broker.priorityClassName }}
+      priorityClassName: {{ .Values.broker.priorityClassName }}
+    {{- end }}
     {{- if .Values.broker.tolerations }}
       tolerations:
 {{ toYaml .Values.broker.tolerations | indent 8 }}

--- a/charts/pulsar/templates/dashboard-deployment.yaml
+++ b/charts/pulsar/templates/dashboard-deployment.yaml
@@ -45,6 +45,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.dashboard.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.dashboard.priorityClassName }}
+      priorityClassName: {{ .Values.dashboard.priorityClassName }}
+    {{- end }}
     {{- if .Values.dashboard.tolerations }}
       tolerations:
 {{ toYaml .Values.dashboard.tolerations | indent 8 }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -57,6 +57,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.proxy.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.proxy.priorityClassName }}
+      priorityClassName: {{ .Values.proxy.priorityClassName }}
+    {{- end }}
     {{- if .Values.proxy.tolerations }}
       tolerations:
 {{ toYaml .Values.proxy.tolerations | indent 8 }}

--- a/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -49,6 +49,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pulsar_manager.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.pulsar_manager.priorityClassName }}
+      priorityClassName: {{ .Values.pulsar_manager.priorityClassName }}
+    {{- end }}
     {{- if .Values.pulsar_manager.tolerations }}
       tolerations:
 {{ toYaml .Values.pulsar_manager.tolerations | indent 8 }}

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -53,6 +53,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.toolset.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.toolset.priorityClassName }}
+      priorityClassName: {{ .Values.toolset.priorityClassName }}
+    {{- end }}
     {{- if .Values.toolset.tolerations }}
       tolerations:
 {{ toYaml .Values.toolset.tolerations | indent 8 }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -54,6 +54,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.zookeeper.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.zookeeper.priorityClassName }}
+      priorityClassName: {{ .Values.zookeeper.priorityClassName }}
+    {{- end }}
     {{- if .Values.zookeeper.tolerations }}
       tolerations:
 {{ toYaml .Values.zookeeper.tolerations | indent 8 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -300,6 +300,7 @@ zookeeper:
     leaderElection: 3888
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
+  # priorityClassName: high-priority-nonpreempting
   probe:
     liveness:
       enabled: true
@@ -440,6 +441,7 @@ bookkeeper:
     statestore: 4181
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
+  # priorityClassName: high-priority-nonpreempting
   probe:
     liveness:
       enabled: true
@@ -616,6 +618,7 @@ autorecovery:
     http: 8000
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
+  # priorityClassName: high-priority-nonpreempting
   affinity:
     anti_affinity: true
     anti_affinity_topology_key: kubernetes.io/hostname
@@ -698,6 +701,7 @@ broker:
     pulsarssl: 6651
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
+  # priorityClassName: high-priority-nonpreempting
   probe:
     liveness:
       enabled: true
@@ -827,6 +831,7 @@ proxy:
   restartPodsOnConfigMapChange: false
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
+  # priorityClassName: high-priority-nonpreempting
   probe:
     liveness:
       enabled: true
@@ -948,6 +953,7 @@ dashboard:
   replicaCount: 1
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
+  # priorityClassName: high-priority-nonpreempting
   annotations: {}
   tolerations: []
   gracePeriod: 0
@@ -994,6 +1000,7 @@ toolset:
   restartPodsOnConfigMapChange: false
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
+  # priorityClassName: high-priority-nonpreempting
   annotations: {}
   tolerations: []
   gracePeriod: 30
@@ -1053,6 +1060,7 @@ pulsar_manager:
   restartPodsOnConfigMapChange: false
   # nodeSelector:
   # cloud.google.com/gke-nodepool: default-pool
+  # priorityClassName: high-priority-nonpreempting
   annotations: {}
   tolerations: []
   gracePeriod: 30


### PR DESCRIPTION
### Motivation

Allow users to configure custom pod priority and preemption by adding the option to set `priorityClassName`.

https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/

### Modifications

Added `priorityClassName` to all deployment and statefulset templates.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
